### PR TITLE
feat: add API root endpoint

### DIFF
--- a/reservations/urls.py
+++ b/reservations/urls.py
@@ -2,10 +2,28 @@ from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import path, include
 from catalogue.views.home import home as catalogue_home
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+
+@api_view(['GET'])
+def api_root(request):
+    return Response({
+        "message": "PIDBooking API",
+        "version": "1.0",
+        "endpoints": {
+            "shows": "/api/shows/",
+            "cart": "/api/cart/",
+            "auth_login": "/api/auth/login/",
+            "auth_logout": "/api/auth/logout/",
+        }
+    })
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("i18n/", include("django.conf.urls.i18n")),
+    path("api/", api_root),
 ]
 
 urlpatterns += i18n_patterns(


### PR DESCRIPTION
## 🔧 Fix 404 sur /api/

### Problème
La route `/api/` retournait une erreur 404 car aucune URL n'était définie pour ce chemin.

### Solution
Ajout d'une vue `api_root` dans `reservations/urls.py` qui retourne un JSON listant les endpoints disponibles.

### Endpoints listés
- `/api/shows/`
- `/api/cart/`
- `/api/auth/login/`
- `/api/auth/logout/`

### Testé ✅
- HTTP 200 OK sur `http://localhost:8000/api/`