### PR TITLE
feat: add RSS feed for upcoming representations

### DIFF
--- a/api/views/rss.py
+++ b/api/views/rss.py
@@ -1,3 +1,6 @@
+from django.contrib.syndication.views import Feed
+from django.utils import timezone
+from catalogue.models.representation import Representation
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -14,3 +17,29 @@ class RssNextRepresentationsView(APIView):
 
     def delete(self, request, *args, **kwargs):
         return Response({"detail": "Placeholder"}, status=501)
+
+
+class UpcomingRepresentationsFeed(Feed):
+    title = "PIDBooking – Prochaines représentations"
+    link = "/api/rss/"
+    description = "Liste des prochaines représentations de spectacles."
+
+    def items(self):
+        return Representation.objects.filter(
+            schedule__gte=timezone.now()
+        ).order_by('schedule')[:20]
+
+    def item_title(self, item):
+        return f"{item.show.title} – {item.schedule.strftime('%d/%m/%Y %H:%M')}"
+
+    def item_description(self, item):
+        lieu = str(item.location) if item.location else 'Non précisé'
+        return (
+            f"Spectacle : {item.show.title}\n"
+            f"Date : {item.schedule.strftime('%d/%m/%Y')}\n"
+            f"Heure : {item.schedule.strftime('%H:%M')}\n"
+            f"Lieu : {lieu}"
+        )
+
+    def item_link(self, item):
+        return f"/api/shows/{item.show.id}/"

--- a/reservations/urls.py
+++ b/reservations/urls.py
@@ -4,6 +4,7 @@ from django.urls import path, include
 from catalogue.views.home import home as catalogue_home
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from api.views.rss import UpcomingRepresentationsFeed
 
 
 @api_view(['GET'])
@@ -24,6 +25,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("i18n/", include("django.conf.urls.i18n")),
     path("api/", api_root),
+    path("api/rss/", UpcomingRepresentationsFeed()),
 ]
 
 urlpatterns += i18n_patterns(


### PR DESCRIPTION
## ✅ Flux RSS – Prochaines représentations

### Endpoint ajouté
- GET /api/rss/ — flux RSS XML des prochaines représentations

### Contenu du flux
- Titre du spectacle + date
- Date, heure et lieu de la représentation
- Lien vers le détail du spectacle

### Testé ✅
- XML valide sur http://localhost:8000/api/rss/
- Spectacle "Manneke" visible avec date et heure