### PR TITLE
feat: add i18n support to HeroSection

### DIFF
--- a/frontend/src/components/HeroSection.jsx
+++ b/frontend/src/components/HeroSection.jsx
@@ -1,18 +1,22 @@
+import { useTranslation } from 'react-i18next'
+
 function HeroSection() {
+  const { t } = useTranslation()
+
   return (
     <section className="home-hero">
       <div className="home-hero__glow home-hero__glow--amber" />
       <div className="home-hero__glow home-hero__glow--blue" />
 
       <div className="home-hero__content">
-        <p className="home-hero__eyebrow">Spectacles, concerts et scenes vivantes</p>
-        <h1>Decouvrez les meilleurs spectacles a Bruxelles</h1>
+        <p className="home-hero__eyebrow">{t('hero.subtitle')}</p>
+        <h1>{t('hero.title')}</h1>
         <p className="home-hero__subtitle">
-          Une selection vibrante d'evenements culturels, reservee en quelques clics.
+          {t('hero.description')}
         </p>
         <div className="home-hero__actions">
           <a href="#shows" className="home-hero__cta">
-            Voir les spectacles
+            {t('hero.cta')}
           </a>
           <span className="home-hero__note">Nouveautes mises a jour en temps reel</span>
         </div>
@@ -25,7 +29,7 @@ function HeroSection() {
         </div>
         <div className="home-hero__poster home-hero__poster--back" />
         <div className="home-hero__ticket">
-          <span>Ce soir</span>
+          <span>{t('hero.tonight')}</span>
           <strong>20:30</strong>
         </div>
       </div>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -5,5 +5,12 @@
   "panier": "Cart",
   "inscription": "Sign up",
   "connexion": "Login",
-  "deconnexion": "Logout"
+  "deconnexion": "Logout",
+  "hero": {
+    "subtitle": "SHOWS, CONCERTS AND LIVE STAGES",
+    "title": "Discover the best shows in Brussels",
+    "description": "A vibrant selection of cultural events, reserved in just a few clicks.",
+    "cta": "View shows",
+    "tonight": "Tonight"
+  }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -5,5 +5,12 @@
   "panier": "Panier",
   "inscription": "Inscription",
   "connexion": "Connexion",
-  "deconnexion": "Deconnexion"
+  "deconnexion": "Deconnexion",
+  "hero": {
+    "subtitle": "SPECTACLES, CONCERTS ET SCÈNES VIVANTES",
+    "title": "Découvrez les meilleurs spectacles à Bruxelles",
+    "description": "Une sélection vibrante d'événements culturels, réservée en quelques clics.",
+    "cta": "Voir les spectacles",
+    "tonight": "Ce soir"
+  }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -5,5 +5,12 @@
   "panier": "Winkelwagen",
   "inscription": "Registreren",
   "connexion": "Inloggen",
-  "deconnexion": "Uitloggen"
+  "deconnexion": "Uitloggen",
+  "hero": {
+    "subtitle": "VOORSTELLINGEN, CONCERTEN EN LEVENDE SCÈNES",
+    "title": "Ontdek de beste voorstellingen in Brussel",
+    "description": "Een levendige selectie culturele evenementen, in een paar klikken gereserveerd.",
+    "cta": "Bekijk de voorstellingen",
+    "tonight": "Vanavond"
+  }
 }


### PR DESCRIPTION
## ✅ i18n Hero Section

### Problème
Le texte du Hero était hardcodé en français, 
le changement de langue n'affectait que la navbar.

### Solution
Ajout du hook useTranslation dans HeroSection.jsx 
et ajout des clés de traduction dans les 3 langues.

### Textes traduits
- Sous-titre : "SPECTACLES, CONCERTS ET SCÈNES VIVANTES"
- Titre principal
- Description
- Bouton CTA "Voir les spectacles"
- "Ce soir"

### Testé ✅
- FR → texte en français ✅
- NL → texte en néerlandais ✅
- EN → texte en anglais ✅