### PR TITLE
feat: add security headers, rate limiting and JWT authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ sqlparse==0.5.3
 tzdata==2025.2
 djangorestframework==3.15.2
 django-modeltranslation==0.18.11
+django-ratelimit==4.1.0
+djangorestframework-simplejwt==5.5.1

--- a/reservations/settings.py
+++ b/reservations/settings.py
@@ -170,3 +170,55 @@ CORS_ALLOWED_ORIGINS = [
 # Email config (console pour le dev)
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DEFAULT_FROM_EMAIL = 'noreply@pidbooking.com'
+
+# ============================================
+# SÉCURITÉ — Headers de protection
+# ============================================
+
+# Protection XSS
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+# Protection Clickjacking
+X_FRAME_OPTIONS = 'DENY'
+
+# Cookies sécurisés
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SAMESITE = 'Lax'
+
+# En production uniquement (mettre True en prod)
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+
+# Referrer Policy
+SECURE_REFERRER_POLICY = 'same-origin'
+
+# ============================================
+# RATE LIMITING
+# ============================================
+RATELIMIT_ENABLE = True
+RATELIMIT_USE_CACHE = 'default'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}
+
+# Rate limiting DRF
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ],
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '10/minute',
+        'user': '100/minute',
+    }
+}

--- a/reservations/urls.py
+++ b/reservations/urls.py
@@ -5,6 +5,7 @@ from django.views.generic import TemplateView
 from catalogue.views.home import home as catalogue_home
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from api.views.rss import UpcomingRepresentationsFeed
 
 
@@ -25,6 +26,8 @@ def api_root(request):
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("i18n/", include("django.conf.urls.i18n")),
+    path("api/token/", TokenObtainPairView.as_view()),
+    path("api/token/refresh/", TokenRefreshView.as_view()),
     path("api/", api_root),
     path("api/rss/", UpcomingRepresentationsFeed()),
 


### PR DESCRIPTION
## ✅ Sécurité — Headers, Rate Limiting, JWT

### Point 1 — Protection XSS et Headers de sécurité
- SECURE_BROWSER_XSS_FILTER activé
- SECURE_CONTENT_TYPE_NOSNIFF activé
- X_FRAME_OPTIONS = 'DENY' (anti-clickjacking)
- SESSION_COOKIE_HTTPONLY et CSRF_COOKIE_HTTPONLY activés
- SESSION_COOKIE_SAMESITE et CSRF_COOKIE_SAMESITE = 'Lax'
- SECURE_REFERRER_POLICY = 'same-origin'

### Point 2 — Rate Limiting via DRF
- Anonymes : 10 requêtes/minute
- Utilisateurs connectés : 100 requêtes/minute
- Via DEFAULT_THROTTLE_CLASSES de Django REST Framework

### Point 3 — JWT Authentication
- Installation de djangorestframework-simplejwt
- POST /api/token/ → obtenir access + refresh token
- POST /api/token/refresh/ → renouveler le token
- JWTAuthentication ajouté dans DEFAULT_AUTHENTICATION_CLASSES

### Testé ✅
- POST /api/token/ avec anna/anna123 → HTTP 200 + tokens générés