### PR TITLE
feat: add CORS configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ djangorestframework==3.15.2
 django-modeltranslation==0.18.11
 django-ratelimit==4.1.0
 djangorestframework-simplejwt==5.5.1
+django-cors-headers==4.9.0

--- a/reservations/settings.py
+++ b/reservations/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "api",
     # ajout de rest_framework
     'rest_framework',
+    'corsheaders',
     # ajout de accounts
     "accounts",
     # ajout de cart
@@ -48,6 +49,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -162,11 +164,6 @@ CSRF_TRUSTED_ORIGINS = [
     'http://127.0.0.1:5173',
 ]
 
-CORS_ALLOWED_ORIGINS = [
-    'http://localhost:5173',
-    'http://127.0.0.1:5173',
-]
-
 # Email config (console pour le dev)
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 DEFAULT_FROM_EMAIL = 'noreply@pidbooking.com'
@@ -222,3 +219,35 @@ REST_FRAMEWORK = {
         'user': '100/minute',
     }
 }
+
+# ============================================
+# CORS — Configuration
+# ============================================
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "http://localhost:3000",
+]
+
+CORS_ALLOW_CREDENTIALS = True
+
+CORS_ALLOW_METHODS = [
+    'DELETE',
+    'GET',
+    'OPTIONS',
+    'PATCH',
+    'POST',
+    'PUT',
+]
+
+CORS_ALLOW_HEADERS = [
+    'accept',
+    'accept-encoding',
+    'authorization',
+    'content-type',
+    'dnt',
+    'origin',
+    'user-agent',
+    'x-csrftoken',
+    'x-requested-with',
+]


### PR DESCRIPTION
## ✅ Sécurité — Configuration CORS

### Problème
Le frontend React (localhost:5173) et le backend Django 
(localhost:8000) sont sur des ports différents. 
Sans CORS, les requêtes sont bloquées par le navigateur.

### Solution
Installation et configuration de django-cors-headers.

### Origines autorisées
- http://localhost:5173 (React dev)
- http://127.0.0.1:5173
- http://localhost:3000

### Méthodes autorisées
GET, POST, PUT, PATCH, DELETE, OPTIONS

### Headers autorisés
authorization, content-type, x-csrftoken, etc.

### Testé ✅
- Serveur Django démarre sans erreur ✅
- Frontend React communique avec le backend ✅