### PR TITLE
feat: add RGPD cookie consent banner

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import ShowsList from './pages/ShowsList'
 import ShowDetail from './pages/ShowDetail'
 import Cart from './pages/Cart'
 import Navbar from './components/Navbar'
+import CookieBanner from './components/CookieBanner'
 import { getStoredUsername, logout } from './services/authService'
 import Checkout from './pages/Checkout'
 
@@ -48,6 +49,7 @@ function App() {
         <Route path="/cart" element={<Cart />} />
         <Route path="/checkout" element={<Checkout />} />
       </Routes>
+      <CookieBanner />
     </BrowserRouter>
   )
 }

--- a/frontend/src/components/CookieBanner.css
+++ b/frontend/src/components/CookieBanner.css
@@ -1,0 +1,66 @@
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #1a1a1a;
+  color: #fff;
+  padding: 20px;
+  z-index: 9999;
+  border-top: 3px solid #FF4500;
+  box-shadow: 0 -4px 20px rgba(0,0,0,0.3);
+}
+
+.cookie-banner__content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.cookie-banner__content h3 {
+  margin: 0;
+  color: #FF4500;
+  font-size: 1rem;
+}
+
+.cookie-banner__content p {
+  margin: 0;
+  flex: 1;
+  font-size: 0.9rem;
+  color: #ccc;
+}
+
+.cookie-banner__buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.cookie-btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: bold;
+}
+
+.cookie-btn--accept {
+  background: #FF4500;
+  color: white;
+}
+
+.cookie-btn--necessary {
+  background: transparent;
+  color: white;
+  border: 1px solid white;
+}
+
+.cookie-btn--decline {
+  background: transparent;
+  color: #aaa;
+  border: 1px solid #555;
+}

--- a/frontend/src/components/CookieBanner.jsx
+++ b/frontend/src/components/CookieBanner.jsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import './CookieBanner.css';
+
+const CookieBanner = () => {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie_consent');
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const acceptAll = () => {
+    localStorage.setItem('cookie_consent', 'all');
+    setVisible(false);
+  };
+
+  const acceptNecessary = () => {
+    localStorage.setItem('cookie_consent', 'necessary');
+    setVisible(false);
+  };
+
+  const decline = () => {
+    localStorage.setItem('cookie_consent', 'declined');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="cookie-banner">
+      <div className="cookie-banner__content">
+        <h3>{t('cookies.title')}</h3>
+        <p>{t('cookies.description')}</p>
+        <div className="cookie-banner__buttons">
+          <button onClick={acceptAll} className="cookie-btn cookie-btn--accept">
+            {t('cookies.accept_all')}
+          </button>
+          <button onClick={acceptNecessary} className="cookie-btn cookie-btn--necessary">
+            {t('cookies.necessary_only')}
+          </button>
+          <button onClick={decline} className="cookie-btn cookie-btn--decline">
+            {t('cookies.decline')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -53,5 +53,12 @@
     "negative_quantity": "Quantity cannot be negative.",
     "loading": "Loading...",
     "error_label": "Error"
+  },
+  "cookies": {
+    "title": "🍪 We use cookies",
+    "description": "We use cookies to improve your experience. You can choose which cookies to accept.",
+    "accept_all": "Accept all",
+    "necessary_only": "Necessary only",
+    "decline": "Decline"
   }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -53,5 +53,12 @@
     "negative_quantity": "La quantité ne peut pas être négative.",
     "loading": "Chargement...",
     "error_label": "Erreur"
+  },
+  "cookies": {
+    "title": "🍪 Nous utilisons des cookies",
+    "description": "Nous utilisons des cookies pour améliorer votre expérience. Vous pouvez choisir quels cookies accepter.",
+    "accept_all": "Tout accepter",
+    "necessary_only": "Nécessaires uniquement",
+    "decline": "Refuser"
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -53,5 +53,12 @@
     "negative_quantity": "Het aantal kan niet negatief zijn.",
     "loading": "Laden...",
     "error_label": "Fout"
+  },
+  "cookies": {
+    "title": "🍪 Wij gebruiken cookies",
+    "description": "Wij gebruiken cookies om uw ervaring te verbeteren. U kunt kiezen welke cookies u accepteert.",
+    "accept_all": "Alles accepteren",
+    "necessary_only": "Alleen noodzakelijke",
+    "decline": "Weigeren"
   }
 }


### PR DESCRIPTION
## ✅ Bandeau cookies RGPD

### Fonctionnalités
- Bandeau fixe en bas de page à la première visite
- 3 options : Tout accepter / Nécessaires / Refuser
- Choix sauvegardé dans localStorage
- Ne réapparaît plus après le choix
- Design cohérent avec le projet (fond noir, orange #FF4500)

### i18n
- Traduit en FR / NL / EN

### Testé ✅
- Bandeau visible en NL ✅
- Boutons fonctionnels ✅
- Disparaît après le choix ✅