### PR TITLE
feat: add HTTPS configuration for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@
 # --- Django ---
 SECRET_KEY=votre-cle-secrete-ici-a-changer-en-production
 DEBUG=True
+DJANGO_ENV=development
 
 # --- Base de données MySQL ---
 # Valeurs par défaut pour MAMP (macOS) :

--- a/reservations/settings.py
+++ b/reservations/settings.py
@@ -251,3 +251,29 @@ CORS_ALLOW_HEADERS = [
     'x-csrftoken',
     'x-requested-with',
 ]
+
+# ============================================
+# HTTPS — Configuration production
+# ============================================
+
+# En production, mettre DEBUG = False et configurer ces paramètres
+PRODUCTION = os.environ.get('DJANGO_ENV') == 'production'
+
+if PRODUCTION:
+    # HTTPS obligatoire
+    SECURE_SSL_REDIRECT = True
+    SECURE_HSTS_SECONDS = 31536000  # 1 an
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+
+    # Cookies sécurisés en production
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+else:
+    # Développement local
+    SECURE_SSL_REDIRECT = False
+    SESSION_COOKIE_SECURE = False
+    CSRF_COOKIE_SECURE = False
+
+# Proxy SSL (si derrière un reverse proxy comme Nginx)
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
## ✅ Sécurité — Configuration HTTPS

### Configuration
- SECURE_SSL_REDIRECT activé en production
- SECURE_HSTS_SECONDS = 31536000 (1 an)
- SECURE_HSTS_INCLUDE_SUBDOMAINS activé
- SECURE_HSTS_PRELOAD activé
- SESSION_COOKIE_SECURE et CSRF_COOKIE_SECURE en production
- SECURE_PROXY_SSL_HEADER configuré pour Nginx

### Environnements
- Développement (DJANGO_ENV=development) → HTTP normal
- Production (DJANGO_ENV=production) → HTTPS forcé

### Testé ✅
- Serveur démarre sans erreur en dev ✅
- Paramètres HTTPS prêts pour la production ✅