### PR TITLE
feat: add slug field to Show model and API

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -66,8 +66,8 @@ urlpatterns = [
 
     # SHOWS
     path('shows/', shows.ShowsView.as_view(), name='shows-list-create'),
-    path('shows/<int:id>/', shows.ShowsDetailView.as_view(), name='shows-detail'),
     path('shows/search/', shows.ShowsSearchView.as_view(), name='shows-search'),
+    path('shows/<slug:slug>/', shows.ShowsDetailView.as_view(), name='shows-detail'),
 
     # REPRESENTATIONS
     path('representations/', representations.RepresentationsView.as_view(),

--- a/api/views/shows.py
+++ b/api/views/shows.py
@@ -37,14 +37,14 @@ class ShowsView(generics.GenericAPIView):
 class ShowsDetailView(generics.GenericAPIView):
     serializer_class = ShowSerializer
 
-    def get_object(self, id):
+    def get_object(self, slug):
         try:
-            return Show.objects.get(id=id)
+            return Show.objects.get(slug=slug)
         except Show.DoesNotExist:
             return None
 
-    def get(self, request, id, *args, **kwargs):
-        show = self.get_object(id)
+    def get(self, request, slug, *args, **kwargs):
+        show = self.get_object(slug)
         if show is None:
             return Response(
                 {"detail": "Spectacle non trouvé"},
@@ -53,8 +53,8 @@ class ShowsDetailView(generics.GenericAPIView):
         serializer = ShowSerializer(show)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    def put(self, request, id, *args, **kwargs):
-        show = self.get_object(id)
+    def put(self, request, slug, *args, **kwargs):
+        show = self.get_object(slug)
         if show is None:
             return Response(
                 {"detail": "Spectacle non trouvé"},
@@ -66,8 +66,8 @@ class ShowsDetailView(generics.GenericAPIView):
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request, id, *args, **kwargs):
-        show = self.get_object(id)
+    def delete(self, request, slug, *args, **kwargs):
+        show = self.get_object(slug)
         if show is None:
             return Response(
                 {"detail": "Spectacle non trouvé"},

--- a/catalogue/forms/ShowForm.py
+++ b/catalogue/forms/ShowForm.py
@@ -7,7 +7,6 @@ class ShowForm(ModelForm):
     class Meta:
         model = Show
         fields = [
-            'slug',
             'title',
             'description',
             'poster_url',
@@ -19,7 +18,6 @@ class ShowForm(ModelForm):
             'publication_status',
         ]
         labels = {
-            'slug': _('Slug'),
             'title': _('Titre'),
             'description': _('Description'),
             'poster_url': _("URL de l'affiche"),

--- a/catalogue/migrations/0027_alter_show_slug_autoslugfield.py
+++ b/catalogue/migrations/0027_alter_show_slug_autoslugfield.py
@@ -1,0 +1,22 @@
+import autoslug.fields
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0026_show_artist_show_publication_status_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='show',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(
+                editable=False,
+                max_length=60,
+                populate_from='title',
+                unique=True,
+            ),
+        ),
+    ]

--- a/catalogue/migrations/0028_populate_show_slugs.py
+++ b/catalogue/migrations/0028_populate_show_slugs.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+from django.utils.text import slugify
+
+
+def populate_slugs(apps, schema_editor):
+    Show = apps.get_model('catalogue', 'Show')
+    for show in Show.objects.filter(slug=''):
+        base = slugify(show.title) or f'show-{show.pk}'
+        slug = base[:60]
+        n = 1
+        while Show.objects.filter(slug=slug).exclude(pk=show.pk).exists():
+            suffix = f'-{n}'
+            slug = base[:60 - len(suffix)] + suffix
+            n += 1
+        show.slug = slug
+        show.save(update_fields=['slug'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0027_alter_show_slug_autoslugfield'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_slugs, migrations.RunPython.noop),
+    ]

--- a/catalogue/models/show.py
+++ b/catalogue/models/show.py
@@ -1,4 +1,5 @@
 from django.db import models
+from autoslug import AutoSlugField
 from .location import *
 
 
@@ -13,7 +14,7 @@ class Show(models.Model):
         APPROVED = "approved", "Approved"
         REJECTED = "rejected", "Rejected"
 
-    slug = models.CharField(max_length=60, unique=True)
+    slug = AutoSlugField(populate_from='title', unique=True, max_length=60, always_update=False)
     title = models.CharField(max_length=255)
     description = models.TextField(max_length=255, null=True)
     poster_url = models.CharField(max_length=255, null=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ djangorestframework-simplejwt==5.5.1
 django-cors-headers==4.9.0
 requests==2.32.3
 django-filter==23.5
+django-autoslug==1.9.9


### PR DESCRIPTION
feat: add slug field to Show model and API

- Ajout du champ slug (AutoSlugField) au modèle Show
- Slug généré automatiquement depuis le titre
- Migrations : création du champ + population des slugs existants
- lookup_field = 'slug' dans le ViewSet (/api/shows/ayiti/)
- Slug ajouté dans le serializer
- Retrait du slug du ShowForm (champ non-éditable)
- Ajout de django-autoslug dans requirements.txt