### PR TITLE
feat: add password reset by email

### DIFF
--- a/api/serializers/auth.py
+++ b/api/serializers/auth.py
@@ -6,3 +6,13 @@ class AuthSerializer(serializers.Serializer):
     username = serializers.CharField(max_length=150)
     password = serializers.CharField(write_only=True)
     # Ajoutez d'autres champs selon les besoins d'authentification
+
+
+class PasswordResetSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    uid = serializers.CharField()
+    token = serializers.CharField()
+    new_password = serializers.CharField(min_length=6, write_only=True)

--- a/api/urls.py
+++ b/api/urls.py
@@ -22,6 +22,8 @@ urlpatterns = [
     path('auth/signup/', auth.AuthSignupView.as_view(), name='auth-signup'),
     path('auth/login/', auth.AuthLoginView.as_view(), name='auth-login'),
     path('auth/logout/', auth.AuthLogoutView.as_view(), name='auth-logout'),
+    path('auth/password-reset/', auth.PasswordResetView.as_view(), name='auth-password-reset'),
+    path('auth/password-reset-confirm/', auth.PasswordResetConfirmView.as_view(), name='auth-password-reset-confirm'),
     # TYPES
     path('types/', types.TypesView.as_view(), name='types-list'),
     path('types/<int:pk>/', types.TypesDetailView.as_view(), name='types-detail'),

--- a/api/views/auth.py
+++ b/api/views/auth.py
@@ -1,9 +1,12 @@
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as auth_login
 from django.contrib.auth import logout as auth_logout
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
 from django.conf import settings
 from django.utils.decorators import method_decorator
+from django.utils.encoding import force_bytes, force_str
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
@@ -203,3 +206,72 @@ def check_email(request):
         'available': not exists,
         'message': 'Disponible' if not exists else 'Déjà utilisé'
     })
+
+
+class PasswordResetView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        email = request.data.get('email', '').strip()
+        if not email:
+            return Response({'error': "L'email est requis."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            # Ne pas révéler si l'email existe ou non
+            return Response({'message': 'Si cet email existe, un lien de réinitialisation a été envoyé.'})
+
+        token = PasswordResetTokenGenerator().make_token(user)
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        reset_url = f'http://localhost:5173/reset-password?token={token}&uid={uid}'
+
+        send_mail(
+            subject='Réinitialisation de votre mot de passe — Brussels Show',
+            message=(
+                f'Bonjour {user.first_name or user.username},\n\n'
+                'Vous avez demandé la réinitialisation de votre mot de passe.\n\n'
+                f'Cliquez sur ce lien pour choisir un nouveau mot de passe :\n{reset_url}\n\n'
+                'Ce lien est valable 24 heures.\n\n'
+                "Si vous n'êtes pas à l'origine de cette demande, ignorez cet email.\n\n"
+                "L'équipe Brussels Show"
+            ),
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[email],
+            fail_silently=False,
+        )
+
+        return Response({'message': 'Si cet email existe, un lien de réinitialisation a été envoyé.'})
+
+
+class PasswordResetConfirmView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        uid = request.data.get('uid', '')
+        token = request.data.get('token', '')
+        new_password = request.data.get('new_password', '')
+
+        if not uid or not token or not new_password:
+            return Response({'error': 'Tous les champs sont requis.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            user_pk = force_str(urlsafe_base64_decode(uid))
+            user = User.objects.get(pk=user_pk)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            return Response({'error': 'Lien invalide.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not PasswordResetTokenGenerator().check_token(user, token):
+            return Response({'error': 'Token invalide ou expiré.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if len(new_password) < 6:
+            return Response({'error': 'Le mot de passe doit contenir au moins 6 caractères.'}, status=status.HTTP_400_BAD_REQUEST)
+        if not re.search(r'[A-Z]', new_password):
+            return Response({'error': 'Le mot de passe doit contenir au moins une majuscule.'}, status=status.HTTP_400_BAD_REQUEST)
+        if not re.search(r'[^a-zA-Z0-9]', new_password):
+            return Response({'error': 'Le mot de passe doit contenir au moins un caractère spécial.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        user.set_password(new_password)
+        user.save()
+
+        return Response({'message': 'Mot de passe réinitialisé avec succès.'})

--- a/api/views/auth.py
+++ b/api/views/auth.py
@@ -265,11 +265,20 @@ class PasswordResetConfirmView(APIView):
             return Response({'error': 'Token invalide ou expiré.'}, status=status.HTTP_400_BAD_REQUEST)
 
         if len(new_password) < 6:
-            return Response({'error': 'Le mot de passe doit contenir au moins 6 caractères.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {'error': 'Le mot de passe doit contenir au moins 6 caractères.'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
         if not re.search(r'[A-Z]', new_password):
-            return Response({'error': 'Le mot de passe doit contenir au moins une majuscule.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {'error': 'Le mot de passe doit contenir au moins une majuscule.'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
         if not re.search(r'[^a-zA-Z0-9]', new_password):
-            return Response({'error': 'Le mot de passe doit contenir au moins un caractère spécial.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {'error': 'Le mot de passe doit contenir au moins un caractère spécial.'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         user.set_password(new_password)
         user.save()


### PR DESCRIPTION
feat: add password reset by email

- POST /api/auth/password-reset/ → envoie un email avec lien de reset
- POST /api/auth/password-reset-confirm/ → change le mot de passe via token
- Utilisation de PasswordResetTokenGenerator de Django
- Email en français avec lien vers le frontend (localhost:5173/reset-password)
- TOKEN valable 24h
- En dev : EMAIL_BACKEND console (affiche l'email dans le terminal)