### PR TITLE
feat: add bulk actions for shows

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -71,6 +71,7 @@ urlpatterns = [
     # SHOWS
     path('shows/', shows.ShowsView.as_view(), name='shows-list-create'),
     path('shows/search/', shows.ShowsSearchView.as_view(), name='shows-search'),
+    path('shows/bulk-actions/', shows.ShowBulkActionsView.as_view(), name='shows-bulk-actions'),
     path('shows/<slug:slug>/', shows.ShowsDetailView.as_view(), name='shows-detail'),
     path('shows/<slug:slug>/reviews/', reviews.ShowReviewsView.as_view(), name='show-reviews'),
     path('shows/<slug:slug>/comments/', comments.ShowCommentsView.as_view(), name='show-comments'),

--- a/api/views/shows.py
+++ b/api/views/shows.py
@@ -1,6 +1,7 @@
 from rest_framework import generics, status
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.views import APIView
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter, OrderingFilter
 from catalogue.models import Show
@@ -75,6 +76,38 @@ class ShowsDetailView(generics.GenericAPIView):
             )
         show.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ShowBulkActionsView(APIView):
+    permission_classes = [IsAdminUser]
+
+    VALID_ACTIONS = ('publish', 'unpublish', 'delete')
+
+    def post(self, request):
+        action = request.data.get('action')
+        ids = request.data.get('ids')
+
+        if action not in self.VALID_ACTIONS:
+            return Response(
+                {'error': f"Action invalide. Valeurs acceptées : {', '.join(self.VALID_ACTIONS)}."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        if not isinstance(ids, list) or not ids:
+            return Response(
+                {'error': "Le champ 'ids' doit être une liste non vide d'identifiants."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        queryset = Show.objects.filter(id__in=ids)
+
+        if action == 'publish':
+            affected = queryset.update(publication_status=Show.PublicationStatus.APPROVED)
+        elif action == 'unpublish':
+            affected = queryset.update(publication_status=Show.PublicationStatus.PENDING)
+        else:
+            affected, _ = queryset.delete()
+
+        return Response({'action': action, 'affected': affected}, status=status.HTTP_200_OK)
 
 
 class ShowsSearchView(generics.GenericAPIView):


### PR DESCRIPTION
feat: add bulk actions for shows

- POST /api/shows/bulk-actions/ → actions groupées sur les spectacles
- Action "publish" → met publication_status à "approved"
- Action "unpublish" → met publication_status à "pending"
- Action "delete" → supprime les spectacles
- Accepte {"action": "...", "ids": [1, 2, 3]}
- Retourne {"action": "...", "affected": X}
- Réservé aux admins (is_staff=True) uniquement