### PR TITLE
feat:inscription producteur + fix login state

### DIFF
--- a/api/views/auth.py
+++ b/api/views/auth.py
@@ -15,6 +15,7 @@ from rest_framework.views import APIView
 from rest_framework import status
 from django.contrib.auth.models import User
 from django.middleware.csrf import get_token
+from api.models import UserProfile
 import re
 
 
@@ -57,6 +58,10 @@ class AuthSignupView(APIView):
         if errors:
             return Response({'errors': errors}, status=status.HTTP_400_BAD_REQUEST)
 
+        role = data.get('role', 'USER')
+        if role not in ('USER', 'PRODUCER'):
+            role = 'USER'
+
         user = User.objects.create_user(
             username=username,
             password=password,
@@ -64,6 +69,9 @@ class AuthSignupView(APIView):
             first_name=first_name,
             last_name=last_name,
         )
+
+        user.profile.role = role
+        user.profile.save()
 
         try:
             send_mail(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import Cart from './pages/Cart'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
 import CookieBanner from './components/CookieBanner'
-import { getStoredUser, storeUser, logout, fetchCurrentUser } from './services/authService'
+import { getStoredUser, storeUser, logout } from './services/authService'
 import Checkout from './pages/Checkout'
 import Search from './pages/Search'
 import Reviews from './pages/Reviews'
@@ -35,28 +35,14 @@ function App() {
   const username = user?.username || null
   const isLoggedIn = !!username
 
-  async function handleLogin(loginData) {
-    if (typeof loginData === 'string') {
-      setUser((prev) => ({ ...prev, username: loginData }))
-      return
-    }
-
+  function handleLogin(loginData) {
     storeUser(loginData)
-    try {
-      const profile = await fetchCurrentUser()
-      storeUser(profile)
-      setUser({
-        username: profile.username || loginData.username,
-        role: profile.role || null,
-        is_staff: !!profile.is_staff,
-      })
-    } catch {
-      setUser({
-        username: loginData.username || null,
-        role: loginData.role || null,
-        is_staff: !!loginData.is_staff,
-      })
-    }
+    setUser({
+      username: loginData.username,
+      role: loginData.role,
+      is_staff: !!loginData.is_staff,
+      email: loginData.email,
+    })
   }
 
   async function handleLogout() {

--- a/frontend/src/pages/AccountPages.css
+++ b/frontend/src/pages/AccountPages.css
@@ -365,6 +365,48 @@
   margin: 0;
 }
 
+.producer-card {
+  grid-column: span 2;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: #1e1e1e;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 16px;
+  cursor: pointer;
+  transition: border-color 180ms ease, background 180ms ease;
+}
+
+.producer-card--active {
+  border-color: #FF4500;
+  background: rgba(255, 69, 0, 0.08);
+}
+
+.producer-card-icon {
+  font-size: 2rem;
+  flex-shrink: 0;
+}
+
+.producer-card strong {
+  color: #f8fafc;
+  display: block;
+}
+
+.producer-card p {
+  margin: 4px 0 0;
+  font-size: 0.88rem;
+  color: #94a3b8;
+}
+
+.producer-card-check {
+  margin-left: auto;
+  color: #FF4500;
+  font-size: 1.5rem;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
 @media (max-width: 900px) {
   .account-hero,
   .account-card-grid,

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -59,6 +59,8 @@ function validateForm(form) {
 
 function Signup() {
   const [form, setForm] = useState(initialForm)
+  const [isProducer, setIsProducer] = useState(false)
+  const role = isProducer ? 'PRODUCER' : 'USER'
   const [touched, setTouched] = useState({})
   const [submitted, setSubmitted] = useState(false)
   const [serverError, setServerError] = useState('')
@@ -125,7 +127,11 @@ function Signup() {
     setServerError('')
     setSuccess('')
 
-    if (!isFormValid) {
+    const password = form.password
+    const confirmPassword = form.passwordConfirm
+    console.log('password:', password, 'confirm:', confirmPassword)
+
+    if (password !== confirmPassword || !isFormValid) {
       return
     }
 
@@ -138,8 +144,9 @@ function Signup() {
         last_name: form.last_name,
         username: form.username,
         password: form.password,
-        password_confirm: form.passwordConfirm,
+        confirm_password: form.passwordConfirm,
         language: form.language,
+        role,
       })
       setSuccess('Inscription terminee. Vous pouvez maintenant vous connecter des que la page de connexion est disponible.')
       setForm(initialForm)
@@ -279,6 +286,15 @@ function Signup() {
 
             <div className="account-password-hint">
               Le mot de passe doit contenir au minimum 6 caracteres, une majuscule et un caractere special.
+            </div>
+
+            <div className={`producer-card${isProducer ? ' producer-card--active' : ''}`} onClick={() => setIsProducer(!isProducer)}>
+              <span className="producer-card-icon">🎭</span>
+              <div>
+                <strong>S&apos;inscrire en tant que Producteur</strong>
+                <p>Gérez vos spectacles, séances et statistiques</p>
+              </div>
+              <span className="producer-card-check">{isProducer ? '✓' : ''}</span>
             </div>
 
             <button className="account-submit" type="submit" disabled={loading || !isFormValid}>

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -131,6 +131,7 @@ export async function logout() {
   localStorage.removeItem('csrf_token')
   localStorage.removeItem('user_role')
   localStorage.removeItem('user_is_staff')
+  localStorage.removeItem('user_email')
 }
 
 export function getStoredUsername() {
@@ -144,6 +145,7 @@ export function getStoredUser() {
     username,
     role: localStorage.getItem('user_role') || null,
     is_staff: localStorage.getItem('user_is_staff') === 'true',
+    email: localStorage.getItem('user_email') || null,
   }
 }
 
@@ -151,6 +153,7 @@ export function storeUser(data) {
   if (data?.username) localStorage.setItem('username', data.username)
   if (data?.role !== undefined) localStorage.setItem('user_role', data.role || '')
   if (data?.is_staff !== undefined) localStorage.setItem('user_is_staff', String(data.is_staff))
+  if (data?.email !== undefined) localStorage.setItem('user_email', data.email || '')
 }
 
 export async function checkUsername(username) {


### PR DESCRIPTION
## Ce qui a été fait

- Ajout d'une carte cliquable "S'inscrire en tant que Producteur" 
  sur la page d'inscription
- Quand la carte est sélectionnée (bordure orange), le compte est 
  créé avec role = PRODUCER
- Fix du bug de login : la navbar affichait l'ancien utilisateur 
  connecté au lieu du nouveau
- Fix du champ confirm_password dans AuthSignupView
- Le menu Espace Producteur apparaît automatiquement dans la navbar 
  après connexion avec un compte PRODUCER

## Comment tester
1. Aller sur /signup
2. Remplir le formulaire
3. Cliquer sur la carte "S'inscrire en tant que Producteur"
4. Cliquer sur S'inscrire
5. Se connecter avec le nouveau compte
6. Le menu Espace Producteur apparaît dans la navbar

## Notes pour l'équipe
- Faire python manage.py migrate après git pull
- Le modèle UserProfile est déjà dans les migrations