### PR TITLE
feat: Espace Producteur complet

### DIFF
--- a/api/views/producer.py
+++ b/api/views/producer.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -9,6 +10,7 @@ from api.serializers.shows import ShowSerializer
 
 
 class ProducerShowsView(APIView):
+    authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
@@ -24,6 +26,7 @@ class ProducerShowsView(APIView):
 
 
 class ProducerShowDetailView(APIView):
+    authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def delete(self, request, slug, *args, **kwargs):
@@ -38,6 +41,9 @@ class ProducerShowDetailView(APIView):
 
 
 class ProducerShowsStatsView(APIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
     def get(self, request, *args, **kwargs):
         return Response({"detail": "Placeholder"}, status=501)
 
@@ -52,6 +58,9 @@ class ProducerShowsStatsView(APIView):
 
 
 class ProducerCommentsView(APIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
     def get(self, request, *args, **kwargs):
         return Response({"detail": "Placeholder"}, status=501)
 
@@ -66,6 +75,9 @@ class ProducerCommentsView(APIView):
 
 
 class ProducerCommentsValidateView(APIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
     def get(self, request, *args, **kwargs):
         return Response({"detail": "Placeholder"}, status=501)
 
@@ -80,6 +92,9 @@ class ProducerCommentsValidateView(APIView):
 
 
 class ProducerCommentsRejectView(APIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
     def get(self, request, *args, **kwargs):
         return Response({"detail": "Placeholder"}, status=501)
 
@@ -94,6 +109,7 @@ class ProducerCommentsRejectView(APIView):
 
 
 class ProducerReviewsView(APIView):
+    authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
@@ -105,6 +121,7 @@ class ProducerReviewsView(APIView):
 
 
 class ProducerReviewModerateView(APIView):
+    authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def patch(self, request, id):
@@ -125,10 +142,16 @@ class ProducerReviewModerateView(APIView):
 
 
 class ProducerReviewsValidateView(APIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
     def post(self, request, *args, **kwargs):
         return Response({"detail": "Placeholder"}, status=501)
 
 
 class ProducerReviewsRejectView(APIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
     def post(self, request, *args, **kwargs):
         return Response({"detail": "Placeholder"}, status=501)

--- a/api/views/shows.py
+++ b/api/views/shows.py
@@ -1,6 +1,7 @@
 from rest_framework import generics, status
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated, IsAdminUser, IsAuthenticatedOrReadOnly
 from rest_framework.views import APIView
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter, OrderingFilter
@@ -10,6 +11,8 @@ from api.filters import ShowFilter
 
 
 class ShowsView(generics.GenericAPIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticatedOrReadOnly]
     queryset = Show.objects.all()
     serializer_class = ShowSerializer
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
@@ -28,10 +31,14 @@ class ShowsView(generics.GenericAPIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def post(self, request, *args, **kwargs):
+        print('USER:', request.user, 'AUTH:', request.user.is_authenticated)
         serializer = ShowSerializer(data=request.data)
         if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
+            if request.user.is_authenticated:
+                show = serializer.save(producer=request.user)
+            else:
+                show = serializer.save()
+            return Response(ShowSerializer(show).data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/api/views/shows.py
+++ b/api/views/shows.py
@@ -43,6 +43,8 @@ class ShowsView(generics.GenericAPIView):
 
 
 class ShowsDetailView(generics.GenericAPIView):
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticatedOrReadOnly]
     serializer_class = ShowSerializer
 
     def get_object(self, slug):
@@ -73,6 +75,9 @@ class ShowsDetailView(generics.GenericAPIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def patch(self, request, slug, *args, **kwargs):
+        return self.put(request, slug, *args, **kwargs)
 
     def delete(self, request, slug, *args, **kwargs):
         show = self.get_object(slug)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -135,6 +135,14 @@ function App() {
           }
         />
         <Route
+          path="/producer/shows/:slug/edit"
+          element={
+            <ProtectedRoute user={user}>
+              <ProducerShowForm />
+            </ProtectedRoute>
+          }
+        />
+        <Route
           path="/producer/shows/:slug/sessions"
           element={
             <ProtectedRoute user={user}>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ import ProducerDashboard from './pages/ProducerDashboard'
 import ProducerShows from './pages/ProducerShows'
 import ProducerSessions from './pages/ProducerSessions'
 import ProducerAllSessions from './pages/ProducerAllSessions'
+import ProducerStats from './pages/ProducerStats'
 
 function ProtectedRoute({ user, children }) {
   if (!user?.username) return <Navigate to="/" replace />
@@ -142,7 +143,11 @@ function App() {
         />
         <Route
           path="/producer/stats"
-          element={<ProtectedRoute user={user}><PlaceholderPage title="Mes statistiques" /></ProtectedRoute>}
+          element={
+            <ProtectedRoute user={user}>
+              <ProducerStats />
+            </ProtectedRoute>
+          }
         />
 
         {/* ── Administration ── */}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,7 @@ import ProducerShows from './pages/ProducerShows'
 import ProducerSessions from './pages/ProducerSessions'
 import ProducerAllSessions from './pages/ProducerAllSessions'
 import ProducerStats from './pages/ProducerStats'
+import ProducerShowForm from './pages/ProducerShowForm'
 
 function ProtectedRoute({ user, children }) {
   if (!user?.username) return <Navigate to="/" replace />
@@ -122,6 +123,14 @@ function App() {
           element={
             <ProtectedRoute user={user}>
               <ProducerShows />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/producer/shows/new"
+          element={
+            <ProtectedRoute user={user}>
+              <ProducerShowForm />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import MyTickets from './pages/MyTickets'
 import ProducerDashboard from './pages/ProducerDashboard'
 import ProducerShows from './pages/ProducerShows'
 import ProducerSessions from './pages/ProducerSessions'
+import ProducerAllSessions from './pages/ProducerAllSessions'
 
 function ProtectedRoute({ user, children }) {
   if (!user?.username) return <Navigate to="/" replace />
@@ -133,7 +134,11 @@ function App() {
         />
         <Route
           path="/producer/sessions"
-          element={<ProtectedRoute user={user}><PlaceholderPage title="Mes séances" /></ProtectedRoute>}
+          element={
+            <ProtectedRoute user={user}>
+              <ProducerAllSessions />
+            </ProtectedRoute>
+          }
         />
         <Route
           path="/producer/stats"

--- a/frontend/src/pages/ProducerAllSessions.css
+++ b/frontend/src/pages/ProducerAllSessions.css
@@ -1,0 +1,233 @@
+.pas-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+  color: #e0e0e0;
+}
+
+/* Breadcrumb */
+.pas-breadcrumb {
+  background: none;
+  border: none;
+  color: #FF4500;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: opacity 0.2s;
+}
+
+.pas-breadcrumb:hover {
+  opacity: 0.75;
+}
+
+/* Header */
+.pas-header {
+  margin-bottom: 32px;
+}
+
+.pas-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0 0 4px;
+}
+
+.pas-subtitle {
+  color: #aaa;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+/* Session list */
+.pas-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pas-card {
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 18px 20px;
+}
+
+.pas-card-show {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #FF4500;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.pas-card-body {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.pas-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.pas-card-datetime {
+  font-weight: 600;
+  color: #fff;
+  font-size: 0.95rem;
+}
+
+.pas-card-loc {
+  color: #aaa;
+  font-size: 0.82rem;
+}
+
+.pas-card-seats {
+  color: #4a9eff;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+/* Empty state */
+.pas-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 60px 24px;
+  color: #888;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+/* Buttons */
+.pas-btn {
+  padding: 9px 18px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  transition: background 0.2s, opacity 0.2s;
+}
+
+.pas-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.pas-btn--primary {
+  background: #FF4500;
+  color: #fff;
+}
+
+.pas-btn--primary:hover:not(:disabled) {
+  background: #e03d00;
+}
+
+.pas-btn--outline {
+  background: transparent;
+  color: #e0e0e0;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.pas-btn--outline:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.pas-btn--danger {
+  background: #c0392b;
+  color: #fff;
+}
+
+.pas-btn--danger:hover:not(:disabled) {
+  background: #a93226;
+}
+
+.pas-btn--sm {
+  padding: 5px 12px;
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+/* State messages */
+.pas-state {
+  color: #888;
+  font-size: 0.95rem;
+  padding: 8px 0;
+  margin: 0;
+}
+
+.pas-state--error {
+  color: #ff6b6b;
+}
+
+/* Confirmation modal */
+.pas-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.pas-modal {
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 32px 28px;
+  max-width: 440px;
+  width: 90%;
+}
+
+.pas-modal-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #fff;
+  margin: 0 0 12px;
+}
+
+.pas-modal-body {
+  color: #bbb;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 24px;
+}
+
+.pas-modal-body strong {
+  color: #fff;
+}
+
+.pas-modal-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+@media (max-width: 600px) {
+  .pas-card-body {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .pas-btn--sm {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/frontend/src/pages/ProducerAllSessions.jsx
+++ b/frontend/src/pages/ProducerAllSessions.jsx
@@ -1,0 +1,187 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import './ProducerAllSessions.css'
+
+const BASE = '/api'
+
+async function apiFetch(path) {
+  const res = await fetch(`${BASE}${path}`, {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  })
+  return res
+}
+
+function toLocalDatetime(isoString) {
+  if (!isoString) return { date: '', time: '' }
+  const d = new Date(isoString)
+  const date = d.toLocaleDateString('fr-BE', { year: 'numeric', month: '2-digit', day: '2-digit' })
+  const time = d.toTimeString().slice(0, 5)
+  return { date, time }
+}
+
+export default function ProducerAllSessions() {
+  const navigate = useNavigate()
+
+  const [sessions,   setSessions]   = useState([])
+  const [showMap,    setShowMap]    = useState({})
+  const [locationMap, setLocationMap] = useState({})
+  const [loading,    setLoading]    = useState(true)
+  const [error,      setError]      = useState(null)
+  const [confirm,    setConfirm]    = useState(null)
+  const [deleting,   setDeleting]   = useState(false)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [showsRes, repsRes, locsRes] = await Promise.all([
+          apiFetch('/producer/shows/'),
+          apiFetch('/representations/'),
+          apiFetch('/locations/'),
+        ])
+
+        if (!showsRes.ok) throw new Error(`Erreur chargement spectacles (${showsRes.status})`)
+        if (!repsRes.ok)  throw new Error(`Erreur chargement séances (${repsRes.status})`)
+        if (!locsRes.ok)  throw new Error(`Erreur chargement lieux (${locsRes.status})`)
+
+        const showsData = await showsRes.json()
+        const repsData  = await repsRes.json()
+        const locsData  = await locsRes.json()
+
+        const shows = Array.isArray(showsData) ? showsData : (showsData.results ?? [])
+        const reps  = Array.isArray(repsData)  ? repsData  : (repsData.results  ?? [])
+        const locs  = Array.isArray(locsData)  ? locsData  : (locsData.results  ?? [])
+
+        const producerShowIds = new Set(shows.map((s) => s.id))
+
+        const sMap = {}
+        shows.forEach((s) => { sMap[s.id] = s.title })
+
+        const lMap = {}
+        locs.forEach((l) => { lMap[l.id] = l.designation })
+
+        setShowMap(sMap)
+        setLocationMap(lMap)
+        setSessions(
+          reps
+            .filter((r) => producerShowIds.has(r.show))
+            .sort((a, b) => new Date(a.schedule) - new Date(b.schedule))
+        )
+      } catch (e) {
+        setError(e.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  async function handleDelete() {
+    if (!confirm) return
+    setDeleting(true)
+    try {
+      const res = await fetch(`${BASE}/representations/${confirm.id}/`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.detail || `Erreur ${res.status}`)
+      }
+      setSessions((prev) => prev.filter((s) => s.id !== confirm.id))
+      setConfirm(null)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="pas-page">
+      <button className="pas-breadcrumb" onClick={() => navigate('/producer/dashboard')}>
+        ← Tableau de bord
+      </button>
+
+      <header className="pas-header">
+        <h1 className="pas-title">Mes séances</h1>
+        {!loading && !error && (
+          <p className="pas-subtitle">
+            {sessions.length} séance{sessions.length !== 1 ? 's' : ''} programmée{sessions.length !== 1 ? 's' : ''}
+          </p>
+        )}
+      </header>
+
+      {loading && <p className="pas-state">Chargement…</p>}
+      {error   && <p className="pas-state pas-state--error">{error}</p>}
+
+      {!loading && !error && sessions.length === 0 && (
+        <div className="pas-empty">
+          <p>Aucune séance programmée.</p>
+          <button className="pas-btn pas-btn--primary" onClick={() => navigate('/producer/shows')}>
+            Gérer mes spectacles
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && sessions.length > 0 && (
+        <ul className="pas-list">
+          {sessions.map((s) => {
+            const { date, time } = toLocalDatetime(s.schedule)
+            return (
+              <li key={s.id} className="pas-card">
+                <div className="pas-card-show">{showMap[s.show] ?? `Spectacle #${s.show}`}</div>
+                <div className="pas-card-body">
+                  <div className="pas-card-info">
+                    <span className="pas-card-datetime">{date} à {time}</span>
+                    <span className="pas-card-loc">{locationMap[s.location] ?? '—'}</span>
+                    <span className="pas-card-seats">
+                      {s.available_seats} place{s.available_seats !== 1 ? 's' : ''} disponible{s.available_seats !== 1 ? 's' : ''}
+                    </span>
+                  </div>
+                  <button
+                    className="pas-btn pas-btn--danger pas-btn--sm"
+                    onClick={() => setConfirm(s)}
+                  >
+                    Supprimer
+                  </button>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {confirm && (
+        <div className="pas-modal-backdrop" onClick={() => !deleting && setConfirm(null)}>
+          <div className="pas-modal" onClick={(e) => e.stopPropagation()}>
+            <h2 className="pas-modal-title">Confirmer la suppression</h2>
+            <p className="pas-modal-body">
+              Voulez-vous supprimer la séance de{' '}
+              <strong>{showMap[confirm.show] ?? `Spectacle #${confirm.show}`}</strong>{' '}
+              du <strong>{toLocalDatetime(confirm.schedule).date}</strong> à{' '}
+              <strong>{toLocalDatetime(confirm.schedule).time}</strong> ?
+              Cette action est irréversible.
+            </p>
+            <div className="pas-modal-actions">
+              <button
+                className="pas-btn pas-btn--outline"
+                onClick={() => setConfirm(null)}
+                disabled={deleting}
+              >
+                Annuler
+              </button>
+              <button
+                className="pas-btn pas-btn--danger"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? 'Suppression…' : 'Supprimer'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ProducerShowForm.css
+++ b/frontend/src/pages/ProducerShowForm.css
@@ -1,0 +1,273 @@
+.psf-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+  color: #e0e0e0;
+}
+
+/* Breadcrumb */
+.psf-breadcrumb {
+  background: none;
+  border: none;
+  color: #FF4500;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: opacity 0.2s;
+}
+
+.psf-breadcrumb:hover {
+  opacity: 0.75;
+}
+
+/* Header */
+.psf-header {
+  margin-bottom: 32px;
+}
+
+.psf-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0;
+}
+
+/* Form */
+.psf-form {
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 32px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Global error */
+.psf-error-global {
+  background: rgba(255, 107, 107, 0.1);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  border-radius: 8px;
+  color: #ff6b6b;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+/* Field */
+.psf-field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.psf-label {
+  font-size: 0.85rem;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.psf-required {
+  color: #FF4500;
+}
+
+.psf-hint {
+  color: #555;
+  font-size: 0.78rem;
+  font-weight: 400;
+}
+
+/* Inputs */
+.psf-input {
+  background: #252525;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 7px;
+  color: #e0e0e0;
+  font-size: 0.9rem;
+  padding: 10px 13px;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+  font-family: inherit;
+}
+
+.psf-input:focus {
+  outline: none;
+  border-color: #FF4500;
+}
+
+.psf-input::placeholder {
+  color: #555;
+}
+
+.psf-input option {
+  background: #252525;
+}
+
+.psf-input--error {
+  border-color: #ff6b6b;
+}
+
+.psf-input--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.psf-textarea {
+  resize: vertical;
+  min-height: 110px;
+}
+
+/* Two-column row */
+.psf-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 540px) {
+  .psf-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Field-level error */
+.psf-field-error {
+  font-size: 0.8rem;
+  color: #ff6b6b;
+}
+
+/* File upload zone */
+.psf-file-zone {
+  border: 2px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+  overflow: hidden;
+  transition: border-color 0.2s, background 0.2s;
+  min-height: 130px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.psf-file-zone:hover {
+  border-color: #FF4500;
+  background: rgba(255, 69, 0, 0.04);
+}
+
+.psf-file-zone--error {
+  border-color: #ff6b6b;
+}
+
+.psf-file-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: #666;
+  font-size: 0.875rem;
+  padding: 28px;
+  text-align: center;
+}
+
+.psf-file-icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.psf-file-hint {
+  font-size: 0.75rem;
+  color: #444;
+}
+
+.psf-preview {
+  width: 100%;
+  max-height: 220px;
+  object-fit: cover;
+  display: block;
+}
+
+.psf-file-hidden {
+  display: none;
+}
+
+.psf-file-remove {
+  background: none;
+  border: none;
+  color: #ff6b6b;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+  align-self: flex-start;
+  transition: opacity 0.2s;
+}
+
+.psf-file-remove:hover {
+  opacity: 0.75;
+}
+
+/* Buttons */
+.psf-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.psf-btn {
+  padding: 10px 24px;
+  border-radius: 7px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, opacity 0.2s;
+  border: none;
+}
+
+.psf-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.psf-btn--primary {
+  background: #FF4500;
+  color: #fff;
+  min-width: 140px;
+}
+
+.psf-btn--primary:hover:not(:disabled) {
+  background: #e03d00;
+}
+
+.psf-btn--outline {
+  background: transparent;
+  color: #e0e0e0;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.psf-btn--outline:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+@media (max-width: 480px) {
+  .psf-form {
+    padding: 24px 16px;
+  }
+
+  .psf-actions {
+    flex-direction: column-reverse;
+  }
+
+  .psf-btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/pages/ProducerShowForm.jsx
+++ b/frontend/src/pages/ProducerShowForm.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import './ProducerShowForm.css'
 
 const BASE = '/api'
@@ -13,6 +13,8 @@ function getCookie(name) {
 
 export default function ProducerShowForm() {
   const navigate   = useNavigate()
+  const { slug }   = useParams()
+  const isEdit     = !!slug
   const fileRef    = useRef(null)
 
   const [types,      setTypes]      = useState([])
@@ -28,6 +30,25 @@ export default function ProducerShowForm() {
   const [posterPreview, setPosterPreview] = useState(null)
   const [submitting, setSubmitting] = useState(false)
   const [errors,     setErrors]     = useState({})
+  const [loading,    setLoading]    = useState(isEdit)
+
+  useEffect(() => {
+    if (!isEdit) return
+    fetch(`${BASE}/shows/${slug}/`, { credentials: 'include', headers: { Accept: 'application/json' } })
+      .then((r) => { if (!r.ok) throw new Error(); return r.json() })
+      .then((data) => {
+        setForm({
+          title:       data.title       ?? '',
+          description: data.description ?? '',
+          genre:       data.artist_types?.[0] ?? '',
+          duration:    data.duration    ?? '',
+          created_in:  data.created_in  ?? '',
+        })
+        if (data.poster_url) setPosterPreview(data.poster_url)
+      })
+      .catch(() => setErrors({ _global: 'Impossible de charger le spectacle.' }))
+      .finally(() => setLoading(false))
+  }, [slug, isEdit])
 
   useEffect(() => {
     const opts = { credentials: 'include', headers: { Accept: 'application/json' } }
@@ -88,8 +109,8 @@ export default function ProducerShowForm() {
     if (posterFile)              fd.append('poster', posterFile)
 
     try {
-      const res = await fetch(`${BASE}/shows/`, {
-        method:      'POST',
+      const res = await fetch(isEdit ? `${BASE}/shows/${slug}/` : `${BASE}/shows/`, {
+        method:      isEdit ? 'PATCH' : 'POST',
         credentials: 'include',
         headers:     { 'X-CSRFToken': getCookie('csrftoken') || localStorage.getItem('csrf_token') || '' },
         body:        fd,
@@ -110,6 +131,8 @@ export default function ProducerShowForm() {
     }
   }
 
+  if (loading) return <div className="psf-page">Chargement…</div>
+
   return (
     <div className="psf-page">
       <button className="psf-breadcrumb" onClick={() => navigate('/producer/shows')}>
@@ -117,7 +140,7 @@ export default function ProducerShowForm() {
       </button>
 
       <header className="psf-header">
-        <h1 className="psf-title">Ajouter un spectacle</h1>
+        <h1 className="psf-title">{isEdit ? 'Modifier le spectacle' : 'Ajouter un spectacle'}</h1>
       </header>
 
       <form className="psf-form" onSubmit={handleSubmit} noValidate>
@@ -266,7 +289,9 @@ export default function ProducerShowForm() {
             className="psf-btn psf-btn--primary"
             disabled={submitting}
           >
-            {submitting ? 'Enregistrement…' : 'Enregistrer'}
+            {submitting
+              ? (isEdit ? 'Mise à jour…' : 'Enregistrement…')
+              : (isEdit ? 'Mettre à jour' : 'Enregistrer')}
           </button>
         </div>
       </form>

--- a/frontend/src/pages/ProducerShowForm.jsx
+++ b/frontend/src/pages/ProducerShowForm.jsx
@@ -1,0 +1,275 @@
+import { useState, useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import './ProducerShowForm.css'
+
+const BASE = '/api'
+
+function getCookie(name) {
+  const value = `; ${document.cookie}`
+  const parts = value.split(`; ${name}=`)
+  if (parts.length === 2) return parts.pop().split(';').shift()
+  return ''
+}
+
+export default function ProducerShowForm() {
+  const navigate   = useNavigate()
+  const fileRef    = useRef(null)
+
+  const [types,      setTypes]      = useState([])
+  const [localities, setLocalities] = useState([])
+  const [form,       setForm]       = useState({
+    title:       '',
+    description: '',
+    genre:       '',
+    duration:    '',
+    created_in:  '',
+  })
+  const [posterFile,   setPosterFile]   = useState(null)
+  const [posterPreview, setPosterPreview] = useState(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [errors,     setErrors]     = useState({})
+
+  useEffect(() => {
+    const opts = { credentials: 'include', headers: { Accept: 'application/json' } }
+    fetch(`${BASE}/types/`, opts)
+      .then((r) => r.json())
+      .then((data) => setTypes(Array.isArray(data) ? data : (data.results ?? [])))
+      .catch(() => {})
+    fetch(`${BASE}/localities/`, opts)
+      .then((r) => r.json())
+      .then((data) => setLocalities(Array.isArray(data) ? data : (data.results ?? [])))
+      .catch(() => {})
+  }, [])
+
+  function handleChange(e) {
+    const { name, value } = e.target
+    setForm((f) => ({ ...f, [name]: value }))
+    if (errors[name]) setErrors((prev) => { const n = { ...prev }; delete n[name]; return n })
+  }
+
+  function handleFile(e) {
+    const file = e.target.files?.[0] ?? null
+    setPosterFile(file)
+    setPosterPreview(file ? URL.createObjectURL(file) : null)
+    if (errors.poster_url) setErrors((prev) => { const n = { ...prev }; delete n.poster_url; return n })
+  }
+
+  function flattenErrors(data) {
+    const out = {}
+    for (const [key, val] of Object.entries(data)) {
+      if (Array.isArray(val))           out[key] = val.join(' ')
+      else if (typeof val === 'string') out[key] = val
+      else                              out[key] = JSON.stringify(val)
+    }
+    return out
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    if (!form.title.trim()) {
+      setErrors({ title: 'Le titre est obligatoire.' })
+      return
+    }
+
+    if (!form.created_in) {
+      setErrors({ created_in: 'La ville de création est obligatoire.' })
+      return
+    }
+
+    setSubmitting(true)
+    setErrors({})
+
+    const fd = new FormData()
+    fd.append('title', form.title.trim())
+    if (form.description.trim()) fd.append('description', form.description.trim())
+    fd.append('created_in', Number(form.created_in))
+    if (form.duration)           fd.append('duration', Number(form.duration))
+    if (form.genre)              fd.append('artist_types', form.genre)
+    if (posterFile)              fd.append('poster', posterFile)
+
+    try {
+      const res = await fetch(`${BASE}/shows/`, {
+        method:      'POST',
+        credentials: 'include',
+        headers:     { 'X-CSRFToken': getCookie('csrftoken') || localStorage.getItem('csrf_token') || '' },
+        body:        fd,
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        const mapped = flattenErrors(data)
+        setErrors(Object.keys(mapped).length ? mapped : { _global: `Erreur ${res.status}` })
+        return
+      }
+
+      navigate('/producer/shows')
+    } catch {
+      setErrors({ _global: 'Erreur réseau. Vérifiez votre connexion.' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="psf-page">
+      <button className="psf-breadcrumb" onClick={() => navigate('/producer/shows')}>
+        ← Mes spectacles
+      </button>
+
+      <header className="psf-header">
+        <h1 className="psf-title">Ajouter un spectacle</h1>
+      </header>
+
+      <form className="psf-form" onSubmit={handleSubmit} noValidate>
+
+        {errors._global && (
+          <p className="psf-error-global">{errors._global}</p>
+        )}
+
+        {/* Titre */}
+        <div className="psf-field">
+          <label className="psf-label" htmlFor="title">
+            Titre <span className="psf-required">*</span>
+          </label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            className={`psf-input${errors.title ? ' psf-input--error' : ''}`}
+            value={form.title}
+            onChange={handleChange}
+            placeholder="Nom du spectacle"
+            required
+          />
+          {errors.title && <span className="psf-field-error">{errors.title}</span>}
+        </div>
+
+        {/* Description */}
+        <div className="psf-field">
+          <label className="psf-label" htmlFor="description">Description</label>
+          <textarea
+            id="description"
+            name="description"
+            className="psf-input psf-textarea"
+            value={form.description}
+            onChange={handleChange}
+            placeholder="Présentation du spectacle…"
+            rows={5}
+          />
+          {errors.description && <span className="psf-field-error">{errors.description}</span>}
+        </div>
+
+        {/* Ville de création */}
+        <div className="psf-field">
+          <label className="psf-label" htmlFor="created_in">
+            Ville de création <span className="psf-required">*</span>
+          </label>
+          <select
+            id="created_in"
+            name="created_in"
+            className={`psf-input${errors.created_in ? ' psf-input--error' : ''}`}
+            value={form.created_in}
+            onChange={handleChange}
+            required
+          >
+            <option value="">— Sélectionner une localité —</option>
+            {localities.map((l) => (
+              <option key={l.id} value={l.id}>{l.locality}</option>
+            ))}
+          </select>
+          {errors.created_in && <span className="psf-field-error">{errors.created_in}</span>}
+        </div>
+
+        {/* Deux colonnes : Genre + Durée */}
+        <div className="psf-row">
+          <div className="psf-field">
+            <label className="psf-label" htmlFor="genre">Genre</label>
+            <select
+              id="genre"
+              name="genre"
+              className={`psf-input${errors.artist_types ? ' psf-input--error' : ''}`}
+              value={form.genre}
+              onChange={handleChange}
+            >
+              <option value="">— Sélectionner —</option>
+              {types.map((t) => (
+                <option key={t.id} value={t.id}>{t.type}</option>
+              ))}
+            </select>
+            {errors.artist_types && <span className="psf-field-error">{errors.artist_types}</span>}
+          </div>
+
+          <div className="psf-field">
+            <label className="psf-label" htmlFor="duration">Durée (minutes)</label>
+            <input
+              id="duration"
+              name="duration"
+              type="number"
+              className={`psf-input${errors.duration ? ' psf-input--error' : ''}`}
+              value={form.duration}
+              onChange={handleChange}
+              placeholder="ex. 90"
+              min={1}
+            />
+            {errors.duration && <span className="psf-field-error">{errors.duration}</span>}
+          </div>
+        </div>
+
+        {/* Affiche */}
+        <div className="psf-field">
+          <label className="psf-label">Affiche</label>
+          <div
+            className={`psf-file-zone${errors.poster_url ? ' psf-file-zone--error' : ''}`}
+            onClick={() => fileRef.current?.click()}
+          >
+            {posterPreview ? (
+              <img src={posterPreview} alt="Aperçu affiche" className="psf-preview" />
+            ) : (
+              <div className="psf-file-placeholder">
+                <span className="psf-file-icon">🖼️</span>
+                <span>Cliquer pour choisir une image</span>
+                <span className="psf-file-hint">JPG, PNG, WEBP — max 5 Mo</span>
+              </div>
+            )}
+          </div>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            className="psf-file-hidden"
+            onChange={handleFile}
+          />
+          {posterPreview && (
+            <button
+              type="button"
+              className="psf-file-remove"
+              onClick={() => { setPosterFile(null); setPosterPreview(null); fileRef.current.value = '' }}
+            >
+              Supprimer l'image
+            </button>
+          )}
+          {errors.poster_url && <span className="psf-field-error">{errors.poster_url}</span>}
+        </div>
+
+        {/* Actions */}
+        <div className="psf-actions">
+          <button
+            type="button"
+            className="psf-btn psf-btn--outline"
+            onClick={() => navigate('/producer/shows')}
+            disabled={submitting}
+          >
+            Annuler
+          </button>
+          <button
+            type="submit"
+            className="psf-btn psf-btn--primary"
+            disabled={submitting}
+          >
+            {submitting ? 'Enregistrement…' : 'Enregistrer'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/ProducerStats.css
+++ b/frontend/src/pages/ProducerStats.css
@@ -1,0 +1,221 @@
+.pst-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+  color: #e0e0e0;
+}
+
+/* Breadcrumb */
+.pst-breadcrumb {
+  background: none;
+  border: none;
+  color: #FF4500;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: opacity 0.2s;
+}
+
+.pst-breadcrumb:hover {
+  opacity: 0.75;
+}
+
+/* Header */
+.pst-header {
+  margin-bottom: 32px;
+}
+
+.pst-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0;
+}
+
+/* Stat cards */
+.pst-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.pst-card {
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pst-card-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1.1;
+}
+
+.pst-card-label {
+  font-size: 0.78rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pst-card-sub {
+  font-size: 0.72rem;
+  color: #555;
+  margin-top: 2px;
+}
+
+/* Chart */
+.pst-chart-section {
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 28px 24px;
+  margin-bottom: 32px;
+}
+
+.pst-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #ffffff;
+  margin: 0 0 24px;
+}
+
+/* Table */
+.pst-table-section {
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 28px 24px;
+}
+
+.pst-table-wrapper {
+  overflow-x: auto;
+}
+
+.pst-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.pst-table thead th {
+  text-align: left;
+  padding: 10px 14px;
+  color: #888;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  white-space: nowrap;
+}
+
+.pst-th--num {
+  text-align: right !important;
+}
+
+.pst-table tbody tr {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  transition: background 0.15s;
+}
+
+.pst-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.pst-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.pst-row--inactive {
+  opacity: 0.55;
+}
+
+.pst-table td {
+  padding: 12px 14px;
+  color: #e0e0e0;
+  vertical-align: middle;
+}
+
+.pst-td--title {
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pst-td--num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+}
+
+.pst-td--muted {
+  color: #555 !important;
+}
+
+.pst-badge {
+  background: rgba(255, 255, 255, 0.08);
+  color: #888;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 7px;
+  border-radius: 4px;
+}
+
+/* Tooltip */
+.pst-tooltip {
+  background: #1a1a1a;
+  border: 1px solid #FF4500;
+  border-radius: 8px;
+  padding: 12px 16px;
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+.pst-tooltip-label {
+  color: #FF4500;
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+
+.pst-tooltip p {
+  margin: 3px 0;
+}
+
+/* State messages */
+.pst-state {
+  color: #888;
+  font-size: 0.95rem;
+  padding: 8px 0;
+  margin: 0;
+}
+
+.pst-state--error {
+  color: #ff6b6b;
+}
+
+@media (max-width: 700px) {
+  .pst-cards {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .pst-cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/ProducerStats.jsx
+++ b/frontend/src/pages/ProducerStats.jsx
@@ -1,0 +1,184 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer,
+} from 'recharts'
+import './ProducerStats.css'
+
+const BASE = '/api'
+
+function StatCard({ label, value, sub }) {
+  return (
+    <div className="pst-card">
+      <span className="pst-card-value">{value ?? '—'}</span>
+      <span className="pst-card-label">{label}</span>
+      {sub && <span className="pst-card-sub">{sub}</span>}
+    </div>
+  )
+}
+
+function CustomTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="pst-tooltip">
+      <p className="pst-tooltip-label">{label}</p>
+      {payload.map((p, i) => (
+        <p key={i} style={{ color: p.color }}>
+          {p.name} : <strong>{p.value?.toLocaleString('fr-BE')}</strong>
+        </p>
+      ))}
+    </div>
+  )
+}
+
+export default function ProducerStats() {
+  const navigate = useNavigate()
+  const [stats,   setStats]   = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error,   setError]   = useState(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`${BASE}/stats/shows/`, {
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        })
+        if (!res.ok) throw new Error(`Impossible de charger les statistiques (${res.status})`)
+        setStats(await res.json())
+      } catch (e) {
+        setError(e.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  const shows       = Array.isArray(stats?.shows) ? stats.shows : []
+  const totalShows  = stats?.total_shows ?? 0
+  const totalReps   = shows.reduce((acc, s) => acc + (s.total_representations ?? 0), 0)
+  const totalSeats  = shows.reduce((acc, s) => acc + (s.total_available_seats  ?? 0), 0)
+  const bookable    = shows.filter((s) => s.bookable).length
+
+  const chartData = shows
+    .filter((s) => s.total_available_seats > 0 || s.total_representations > 0)
+    .map((s) => ({
+      name:    s.title?.length > 22 ? s.title.slice(0, 22) + '…' : (s.title || `#${s.show_id}`),
+      places:  s.total_available_seats ?? 0,
+      séances: s.total_representations ?? 0,
+    }))
+    .sort((a, b) => b.places - a.places)
+    .slice(0, 12)
+
+  const chartHeight = Math.max(180, chartData.length * 44)
+
+  return (
+    <div className="pst-page">
+      <button className="pst-breadcrumb" onClick={() => navigate('/producer/dashboard')}>
+        ← Tableau de bord
+      </button>
+
+      <header className="pst-header">
+        <h1 className="pst-title">Mes statistiques</h1>
+      </header>
+
+      {loading && <p className="pst-state">Chargement…</p>}
+      {error   && <p className="pst-state pst-state--error">{error}</p>}
+
+      {!loading && !error && (
+        <>
+          {/* ── Cartes ── */}
+          <section className="pst-cards">
+            <StatCard label="Spectacles"         value={totalShows} />
+            <StatCard label="Représentations"    value={totalReps} />
+            <StatCard
+              label="Places disponibles"
+              value={totalSeats.toLocaleString('fr-BE')}
+            />
+            <StatCard
+              label="Taux de remplissage"
+              value="—"
+              sub="données non disponibles"
+            />
+          </section>
+
+          {/* ── Graphique horizontal ── */}
+          <section className="pst-chart-section">
+            <h2 className="pst-section-title">Places disponibles par spectacle</h2>
+            {chartData.length > 0 ? (
+              <ResponsiveContainer width="100%" height={chartHeight}>
+                <BarChart
+                  layout="vertical"
+                  data={chartData}
+                  margin={{ top: 4, right: 48, left: 8, bottom: 4 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2a" horizontal={false} />
+                  <XAxis
+                    type="number"
+                    tick={{ fill: '#aaa', fontSize: 12 }}
+                    tickFormatter={(v) => v.toLocaleString('fr-BE')}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    width={180}
+                    tick={{ fill: '#e0e0e0', fontSize: 12 }}
+                  />
+                  <Tooltip content={<CustomTooltip />} />
+                  <Bar
+                    dataKey="places"
+                    name="Places disponibles"
+                    fill="#FF4500"
+                    radius={[0, 6, 6, 0]}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="pst-state">Aucune donnée disponible.</p>
+            )}
+          </section>
+
+          {/* ── Tableau détaillé ── */}
+          <section className="pst-table-section">
+            <h2 className="pst-section-title">Détail par spectacle</h2>
+            {shows.length === 0 ? (
+              <p className="pst-state">Aucun spectacle enregistré.</p>
+            ) : (
+              <div className="pst-table-wrapper">
+                <table className="pst-table">
+                  <thead>
+                    <tr>
+                      <th>Titre</th>
+                      <th className="pst-th--num">Représentations</th>
+                      <th className="pst-th--num">Places totales</th>
+                      <th className="pst-th--num">Places vendues</th>
+                      <th className="pst-th--num">Taux de remplissage</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {shows.map((s) => (
+                      <tr key={s.show_id} className={s.bookable ? '' : 'pst-row--inactive'}>
+                        <td className="pst-td--title">
+                          {s.title}
+                          {!s.bookable && <span className="pst-badge">Inactif</span>}
+                        </td>
+                        <td className="pst-td--num">{s.total_representations}</td>
+                        <td className="pst-td--num">
+                          {s.total_available_seats?.toLocaleString('fr-BE') ?? '—'}
+                        </td>
+                        <td className="pst-td--num pst-td--muted">—</td>
+                        <td className="pst-td--num pst-td--muted">—</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Ce qui a été fait

- Menu Espace Producteur orange dans la navbar
- Dashboard avec stats et graphique combiné barres/ligne
- Gestion des spectacles (liste, ajout, modification, suppression)
- Gestion des séances par spectacle (ajout, suppression)
- Page Mes séances (toutes les séances en un endroit)
- Page Mes statistiques (cartes + graphique barres horizontales)
- Inscription en tant que Producteur sur la page signup
- Fix login (le bon utilisateur s'affiche après connexion)
- Modèle UserProfile avec champ role (USER/PRODUCER/ADMIN)

## Pour l'équipe après git pull
- Lancer : python manage.py migrate
- S'inscrire sur /signup avec la carte Producteur