### PR TITLE
feat: add Locations page and admin stats dashboard

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -144,6 +144,7 @@ urlpatterns = [
 
     # ADMIN
     path('admin/users/', admin_api.AdminApiUsersView.as_view(), name='admin-users'),
+    path('admin/stats/', admin_api.AdminStatsView.as_view(), name='admin-stats'),
     path('admin/users/<int:id>/status/', admin_api.AdminApiUserStatusView.as_view(), name='admin-users-status'),
     path('admin/comments/', admin_api.AdminCommentsView.as_view(), name='admin-comments'),
     path(

--- a/api/views/admin_api.py
+++ b/api/views/admin_api.py
@@ -1,13 +1,37 @@
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.models import User
+from django.db.models import Sum, F, DecimalField
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
-from catalogue.models import Comment
+from catalogue.models import Comment, Reservation, Show
 from api.models import UserProfile
 from api.serializers.comments import CommentAdminSerializer, CommentModerationSerializer
 from api.serializers.admin_api import UserListAdminSerializer
+
+
+class AdminStatsView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, *args, **kwargs):
+        total_users = User.objects.count()
+        total_shows = Show.objects.count()
+        total_reservations = Reservation.objects.count()
+        pending_reservations = Reservation.objects.filter(payment_status='pending').count()
+        revenue = Reservation.objects.filter(payment_status='paid').aggregate(
+            total=Sum(
+                F('representation_reservations__price__price') * F('representation_reservations__quantity'),
+                output_field=DecimalField(max_digits=12, decimal_places=2)
+            )
+        )['total'] or 0
+        return Response({
+            'total_users': total_users,
+            'total_shows': total_shows,
+            'total_reservations': total_reservations,
+            'pending_reservations': pending_reservations,
+            'revenue': float(revenue),
+        })
 
 
 class AdminApiUsersView(APIView):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,6 +41,7 @@ import AdminProducers from "./pages/AdminProducers"
 import AdminUsers from "./pages/AdminUsers"
 import AdminShows from "./pages/AdminShows"
 import AdminReservations from "./pages/AdminReservations"
+import Locations from "./pages/Locations"
 
 import {
   getStoredUser,
@@ -298,6 +299,8 @@ function AppContent() {
         <Route path="/:lang/shows/:slug" element={<ShowDetail />} />
         <Route path="/cart" element={<Cart />} />
         <Route path="/:lang/cart" element={<Cart />} />
+        <Route path="/locations" element={<Locations />} />
+        <Route path="/:lang/locations" element={<Locations />} />
         <Route path="/checkout" element={<Checkout />} />
         <Route path="/:lang/checkout" element={<Checkout />} />
         <Route

--- a/frontend/src/components/navbar/AuthenticatedNavbar.jsx
+++ b/frontend/src/components/navbar/AuthenticatedNavbar.jsx
@@ -193,6 +193,17 @@ function AuthenticatedNavbar({ user, onLogout, localizedPath, selectedLang, setS
           </Link>
         )}
 
+        {/* Locations */}
+        <Link
+          to={localizedPath('/locations')}
+          style={{
+            ...actionStyle,
+            transform: 'translateY(0)',
+          }}
+        >
+          <span>📍 {t('navbar.admin_locations')}</span>
+        </Link>
+
         {/* Language Selector */}
         <NavbarLanguageSelector
           selectedLang={selectedLang}

--- a/frontend/src/components/navbar/GuestNavbar.jsx
+++ b/frontend/src/components/navbar/GuestNavbar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import NavbarGuestLogo from './NavbarGuestLogo'
 import NavbarLanguageSelector from './NavbarLanguageSelector'
@@ -22,7 +22,7 @@ function replacePathLanguage(pathname, language) {
 }
 
 function GuestNavbar({ onLogin }) {
-  const { i18n } = useTranslation()
+  const { i18n, t } = useTranslation()
   const location = useLocation()
   const navigate = useNavigate()
   const [showModal, setShowModal] = useState(false)
@@ -88,6 +88,12 @@ function GuestNavbar({ onLogin }) {
               className="flex items-center gap-6"
               style={{ display: 'flex', alignItems: 'center', gap: '12px', marginLeft: 'auto', paddingRight: '16px' }}
             >
+              <Link
+                to={localizedPath('/locations')}
+                style={{ color: 'white', textDecoration: 'none', fontWeight: 600, fontSize: '0.95rem' }}
+              >
+                📍 {t('navbar.admin_locations')}
+              </Link>
               <NavbarLanguageSelector
                 selectedLang={selectedLang}
                 onLanguageChange={handleLanguageChange}

--- a/frontend/src/pages/AdminDashboard.css
+++ b/frontend/src/pages/AdminDashboard.css
@@ -49,6 +49,44 @@
   white-space: nowrap;
 }
 
+.admin-stats-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 720px;
+  margin: 0 auto 28px auto;
+}
+
+.admin-stat-card {
+  flex: 1;
+  min-width: 120px;
+  background: #1e1e1e;
+  border: 1px solid #d9911d;
+  border-radius: 12px;
+  padding: 18px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.admin-stat-value {
+  font-size: 1.8rem;
+  font-weight: 900;
+  color: #d9911d;
+  line-height: 1;
+}
+
+.admin-stat-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #aaa;
+  text-align: center;
+}
+
 .admin-cards-container {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -25,11 +25,21 @@ async function fetchPendingProducers() {
   return res.json()
 }
 
+async function fetchAdminStats() {
+  const res = await fetch(`${BASE}/admin/stats/`, {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) throw new Error('Unable to load stats')
+  return res.json()
+}
+
 export default function AdminDashboard() {
   const { t, i18n } = useTranslation()
   const normalizedLang = (i18n.language || 'fr').slice(0, 2).toLowerCase()
   const [pendingCount, setPendingCount] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [stats, setStats] = useState(null)
 
   useEffect(() => {
     fetchPendingProducers()
@@ -39,6 +49,10 @@ export default function AdminDashboard() {
       })
       .catch(() => setPendingCount(0))
       .finally(() => setLoading(false))
+
+    fetchAdminStats()
+      .then((data) => setStats(data))
+      .catch(() => setStats(null))
   }, [])
 
   function localizedPath(path) {
@@ -48,6 +62,31 @@ export default function AdminDashboard() {
 
   return (
     <main className="account-shell">
+      {stats && (
+        <div className="admin-stats-row">
+          <div className="admin-stat-card">
+            <span className="admin-stat-value">{stats.total_users}</span>
+            <span className="admin-stat-label">Utilisateurs</span>
+          </div>
+          <div className="admin-stat-card">
+            <span className="admin-stat-value">{stats.total_shows}</span>
+            <span className="admin-stat-label">Spectacles</span>
+          </div>
+          <div className="admin-stat-card">
+            <span className="admin-stat-value">{stats.total_reservations}</span>
+            <span className="admin-stat-label">Réservations</span>
+          </div>
+          <div className="admin-stat-card">
+            <span className="admin-stat-value">{stats.pending_reservations}</span>
+            <span className="admin-stat-label">En attente paiement</span>
+          </div>
+          <div className="admin-stat-card">
+            <span className="admin-stat-value">{stats.revenue.toFixed(2)}€</span>
+            <span className="admin-stat-label">Revenus</span>
+          </div>
+        </div>
+      )}
+
       <section className="pd-cards admin-cards-container">
         {ADMIN_SECTIONS.map((section) => (
           <Link


### PR DESCRIPTION
- Ajout du bouton "Nos lieux" dans la navbar (connecté et non connecté)
- Ajout de la route /locations accessible à tous
- Ajout du endpoint /api/admin/stats/ (users, shows, réservations, revenus)
- Affichage des stats en haut du tableau de bord admin